### PR TITLE
fixing button text style prop type error 

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -2,7 +2,7 @@ import React, { Component, useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import {
   StyleSheet,
-  Text,
+  TextPropTypes,
   View,
   Animated,
   TouchableOpacity
@@ -335,7 +335,7 @@ ActionButton.propTypes = {
   bgColor: PropTypes.string,
   bgOpacity: PropTypes.number,
   buttonColor: PropTypes.string,
-  buttonTextStyle: Text.propTypes.style,
+  buttonTextStyle: TextPropTypes,
   buttonText: PropTypes.string,
 
   offsetX: PropTypes.number,


### PR DESCRIPTION
This typeError appears in Ons Vandaag, because of this we are not able to compile the app with the latest react version.

I've checked the way of getting props for the Text component, and it also ends up in the same way as TextPropTypes using `this interface export interface TextProps extends TextPropsIOS, TextPropsAndroid, AccessibilityProps`
