### PR TITLE
fix: buttonTextStyle props

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -2,7 +2,6 @@ import React, { Component, useState, useRef, useEffect } from "react";
 import PropTypes from "prop-types";
 import {
   StyleSheet,
-  TextPropTypes,
   View,
   Animated,
   TouchableOpacity
@@ -335,7 +334,11 @@ ActionButton.propTypes = {
   bgColor: PropTypes.string,
   bgOpacity: PropTypes.number,
   buttonColor: PropTypes.string,
-  buttonTextStyle: TextPropTypes,
+  buttonTextStyle: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
+    PropTypes.number
+  ]),
   buttonText: PropTypes.string,
 
   offsetX: PropTypes.number,


### PR DESCRIPTION
## **Description**

A fix for consuming apps (Ons Vandaag - chaos):  

```
ERROR  Warning: Failed prop type: ActionButton: prop type `buttonTextStyle` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.
    at ActionButton (http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.nedap.healthcare.today.debug&modulesOnly=false&runModule=true:266623:47)
```